### PR TITLE
code improvements and Added generic methods

### DIFF
--- a/src/Chest.Client/Chest.Client.csproj
+++ b/src/Chest.Client/Chest.Client.csproj
@@ -15,6 +15,15 @@
     <LangVersion>latest</LangVersion>
     <DocumentationFile>bin\Debug\netstandard2.0\Chest.Client.xml</DocumentationFile>
     <NoWarn>1701;1702;1705;CA2007</NoWarn>
+    <Version>0.1.1</Version>
+    <AssemblyVersion>0.1.0.1</AssemblyVersion>
+    <FileVersion>0.1.0.1</FileVersion>
+    <Description>Provides a client on Chest.
+The chest is a metadata service with only two endpoints Add and Get.</Description>
+    <PackageReleaseNotes>Implemented generic methods, Add&lt;T&gt; and T Get&lt;T&gt;.
+Used serialization extensions helper inside these new methods to simplify usage of the client.
+Serialize instance of any class to dictionary with extension method `instanceObject.ToMetadataDictionary()`
+To deserialize metadata dictionary to instance object use `dictionary.ToObject&lt;T&gt;()`</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Chest.Client/Extensions/SerializationExtensions.cs
+++ b/src/Chest.Client/Extensions/SerializationExtensions.cs
@@ -1,0 +1,102 @@
+﻿// Copyright (c) Lykke Corp.
+// See the LICENSE file in the project root for more information.
+
+namespace Chest.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq;
+    using System.Reflection;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Extension methods for object to <see cref="Dictionary{TKey, TValue}"/> and vice versa
+    /// </summary>
+    public static class SerializationExtensions
+    {
+        /// <summary>
+        /// Converts an instance object to <see cref="Dictionary{TKey, TValue}"/>
+        /// </summary>
+        /// <typeparam name="T">Any class type T</typeparam>
+        /// <param name="instance">The instance object of given generic type T</param>
+        /// <returns>A <see cref="Dictionary{TKey, TValue}"/> which can be stored as Metadata</returns>
+        public static Dictionary<string, string> ToMetadataDictionary<T>(this T instance)
+            where T : class
+        {
+            var properties = instance
+                .GetType()
+                .GetProperties(BindingFlags.Instance | BindingFlags.Public);
+
+            if (!properties.Any(p => p.PropertyType.IsClass && p.PropertyType != typeof(string)))
+            {
+                return properties.ToDictionary(p => p.Name, p => Convert.ToString(p.GetValue(instance, null), CultureInfo.InvariantCulture));
+            }
+
+            Dictionary<string, string> dictionary = new Dictionary<string, string>();
+
+            foreach (var property in properties)
+            {
+                if (property.PropertyType.IsClass
+                    && property.PropertyType != typeof(string))
+                {
+                    dictionary[property.Name] = JsonConvert.SerializeObject(property.GetValue(instance, null).ToMetadataDictionary());
+                    continue;
+                }
+
+                dictionary[property.Name] = Convert.ToString(property.GetValue(instance, null), CultureInfo.InvariantCulture);
+            }
+
+            return dictionary;
+        }
+
+        /// <summary>
+        /// Converts a metadata dictionary to instance object of the given generic type
+        /// </summary>
+        /// <typeparam name="T">Any class type T having parameter-less constructor</typeparam>
+        /// <param name="metadataDictionary">A <see cref="Dictionary{TKey, TValue}"/> dictionary</param>
+        /// <returns>Instance object of the generic type T</returns>
+        public static T To<T>(this Dictionary<string, string> metadataDictionary)
+            where T : class, new()
+        {
+            var t = new T();
+
+            var properties = t.GetType().GetProperties();
+
+            foreach (var property in properties)
+            {
+                var value = metadataDictionary[property.Name];
+
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    continue;
+                }
+
+                if (property.PropertyType.IsEnum)
+                {
+                    property.SetValue(t, Enum.Parse(property.PropertyType, value));
+                    continue;
+                }
+
+                if (property.PropertyType == typeof(string)
+                    || !property.PropertyType.IsClass)
+                {
+                    property.SetValue(t, Convert.ChangeType(value, property.PropertyType, CultureInfo.InvariantCulture));
+
+                    continue;
+                }
+
+                var nestedDictionary = JsonConvert.DeserializeObject<Dictionary<string, string>>(value);
+
+                var objectValue = typeof(SerializationExtensions)
+                    .GetMethod(nameof(To), BindingFlags.Static | BindingFlags.Public)
+                    .MakeGenericMethod(property.PropertyType)
+                    .Invoke(null, new object[] { nestedDictionary });
+
+                property.SetValue(t, objectValue);
+            }
+
+            return t;
+        }
+    }
+}

--- a/src/Chest.Client/IMetadataClient.cs
+++ b/src/Chest.Client/IMetadataClient.cs
@@ -3,6 +3,7 @@
 
 namespace Chest.Client
 {
+    using System;
     using System.Threading;
     using System.Threading.Tasks;
     using Chest.Dto;
@@ -18,7 +19,19 @@ namespace Chest.Client
         /// <param name="data">The metadata to store.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>A task object representing the asynchronous operation.</returns>
+        [Obsolete("Use generic method Add<T> instead")]
         Task Add(Metadata data, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Adds the specified instance as metadata against the given key.
+        /// </summary>
+        /// <typeparam name="T">Type of the instance object to store as metadata</typeparam>
+        /// <param name="key">Unique key for which to store metadata</param>
+        /// <param name="instance">The instance object of type T</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A task object representing the asynchronous operation.</returns>
+        Task Add<T>(string key, T instance, CancellationToken cancellationToken = default)
+            where T : class;
 
         /// <summary>
         /// Gets metadata for specified key.
@@ -26,6 +39,19 @@ namespace Chest.Client
         /// <param name="key">The metadata key.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>A task object representing the asynchronous operation.</returns>
+        [Obsolete("Use Generic method Get<T> instead")]
         Task<Metadata> GetMetadata(string key, CancellationToken cancellationToken = default);
+
+#pragma warning disable CA1716 // Identifiers should not match keywords
+        /// <summary>
+        /// Gets metadata for specified key.
+        /// </summary>
+        /// <typeparam name="T">The type for which the metada was saved</typeparam>
+        /// <param name="key">Unique key for which to get metadata</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>Instance object of the type T containing all the metadata information against the given key</returns>
+        Task<T> Get<T>(string key, CancellationToken cancellationToken = default)
+            where T : class, new();
+#pragma warning restore CA1716
     }
 }

--- a/src/Chest.Client/MetadataClient.cs
+++ b/src/Chest.Client/MetadataClient.cs
@@ -7,6 +7,7 @@ namespace Chest.Client
     using System.Threading;
     using System.Threading.Tasks;
     using Chest.Dto;
+    using Chest.Extensions;
 
     /// <summary>
     /// Exposes public members of Metadata client
@@ -37,6 +38,26 @@ namespace Chest.Client
             this.SendAsync(HttpMethod.Post, this.RelativeUrl($"{ApiPath}"), data, cancellationToken);
 
         /// <summary>
+        /// Adds the specified instance as metadata against the given key.
+        /// </summary>
+        /// <typeparam name="T">Type of the instance object to store as metadata</typeparam>
+        /// <param name="key">Unique key for which to store metadata</param>
+        /// <param name="instance">The instance object of type T</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A task object representing the asynchronous operation.</returns>
+        public Task Add<T>(string key, T instance, CancellationToken cancellationToken = default)
+            where T : class
+        {
+            var metadata = new Metadata
+            {
+                Key = key,
+                Data = instance.ToMetadataDictionary()
+            };
+
+            return this.SendAsync(HttpMethod.Post, this.RelativeUrl($"{ApiPath}"), metadata, cancellationToken);
+        }
+
+        /// <summary>
         /// Gets metadata for specified key.
         /// </summary>
         /// <param name="key">The metadata key.</param>
@@ -44,5 +65,20 @@ namespace Chest.Client
         /// <returns>A task object representing the asynchronous operation.</returns>
         public Task<Metadata> GetMetadata(string key, CancellationToken cancellationToken = default) =>
             this.GetAsync<Metadata>(this.RelativeUrl($"{ApiPath}/{NotNull(key, nameof(key))}"), cancellationToken);
+
+        /// <summary>
+        /// Gets metadata for specified key.
+        /// </summary>
+        /// <typeparam name="T">The type for which the metada was saved</typeparam>
+        /// <param name="key">Unique key for which to get metadata</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>Instance object of the type T containing all the metadata information against the given key</returns>
+        public async Task<T> Get<T>(string key, CancellationToken cancellationToken = default)
+            where T : class, new()
+        {
+            var metadata = await this.GetAsync<Metadata>(this.RelativeUrl($"{ApiPath}/{NotNull(key, nameof(key))}"), cancellationToken);
+
+            return metadata?.Data?.To<T>();
+        }
     }
 }

--- a/src/Docker/docker-compose.dcproj
+++ b/src/Docker/docker-compose.dcproj
@@ -5,7 +5,7 @@
     <DockerTargetOS>Linux</DockerTargetOS>
     <ProjectGuid>63E46172-8B70-43CD-AB6F-A0D4DEEE1089</ProjectGuid>
     <DockerLaunchBrowser>True</DockerLaunchBrowser>
-    <DockerServiceUrl>http://localhost:5007</DockerServiceUrl>
+    <DockerServiceUrl>http://localhost:5011</DockerServiceUrl>
     <DockerServiceName>chest</DockerServiceName>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Docker/docker-compose.override.yml
+++ b/src/Docker/docker-compose.override.yml
@@ -8,10 +8,10 @@ services:
       - chest
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
-      - ${LOG_PATH:-/var/log}:/var/log
+      - ${LOG_PATH:-./var/log}:/var/log
     ports:
       - "5011:80"
 
   chest:
     ports:
-      - "5008:80"
+      - 80

--- a/src/Docker/docker-compose.yml
+++ b/src/Docker/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       args:
         version: ${VERSION:-0.1.0-developer}
     container_name: chest
+    depends_on:
+      - postgres
     environment:
       - ASPNETCORE_ENVIRONMENT=Docker
       - CHEST_CONNECTIONSTRING=${CHEST_CONNECTIONSTRING:-Host=postgres;Port=5432;Database=Chest;User Id=chest;Password=secret}

--- a/src/tests/Chest.Tests/Dto/AssetAccountMetadata.cs
+++ b/src/tests/Chest.Tests/Dto/AssetAccountMetadata.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Lykke Corp.
+// See the LICENSE file in the project root for more information.
+
+namespace Chest.Tests.Dto
+{
+    public class AssetAccountMetadata
+    {
+        public string AccountNumber { get; set; }
+
+        public string MarginAccount { get; set; }
+
+        public string ReferenceAccount { get; set; }
+
+        public string BankIdentificationReference { get; set; }
+    }
+}

--- a/src/tests/Chest.Tests/Integration/MetadataManagement.cs
+++ b/src/tests/Chest.Tests/Integration/MetadataManagement.cs
@@ -9,6 +9,7 @@ namespace Chest.Tests.Integration
     using System.Threading.Tasks;
     using Chest.Client;
     using Chest.Dto;
+    using Chest.Tests.Dto;
     using Chest.Tests.Sdk;
     using FluentAssertions;
     using Xbehave;
@@ -195,6 +196,42 @@ namespace Chest.Tests.Integration
                 {
                     Assert.Equal(HttpStatusCode.Conflict, httpException.StatusCode);
                     Assert.NotNull(httpException.ContentMessage);
+                });
+        }
+
+        [Scenario]
+        public void CanAddMetadataUsingDto()
+        {
+            var client = new MetadataClient(this.ServiceUrl);
+            var key = "556988";
+
+            var expected = new AssetAccountMetadata
+            {
+                    AccountNumber = key ,
+                    MarginAccount = "MA01",
+                    ReferenceAccount = "RF11",
+                    BankIdentificationReference = "BIR11",
+            };
+
+            AssetAccountMetadata actual = null;
+
+            $"Given the AssetAccountMetadata for key: {key}"
+                .x(async () =>
+                {
+                    await client.Add(key, expected).ConfigureAwait(false);
+                });
+
+            $"When try to get AssetAccountMetadata for the key: {key}"
+                .x(async () =>
+                {
+                    actual = await client.Get<AssetAccountMetadata>(key).ConfigureAwait(false);
+                });
+
+            "Then the fetched AssetAccountMetadata should be same"
+                .x(() =>
+                {
+                    Assert.NotNull(actual);
+                    actual.Should().BeEquivalentTo(expected);
                 });
         }
     }

--- a/src/tests/Chest.Tests/Unit/SerializationExtensionsTests.cs
+++ b/src/tests/Chest.Tests/Unit/SerializationExtensionsTests.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Lykke Corp.
+// See the LICENSE file in the project root for more information.
+
+namespace Chest.Tests.Unit
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using Chest.Extensions;
+    using FluentAssertions;
+    using Xbehave;
+
+    public class SerializationExtensionsTests
+    {
+        [Scenario]
+        public void DataShouldNotLostWhenSerializedDeserialized()
+        {
+            ExampleClass expected = null;
+            ExampleClass actual = null;
+            Dictionary<string, string> dictionary = default(Dictionary<string, string>);
+
+            "Given an instance object of a class ExampleClass"
+                .x(() =>
+                {
+                    expected = new ExampleClass
+                    {
+                        Id = 5,
+                        Name = "DAX_INDEX",
+                        Timestamp = DateTime.ParseExact(DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture), "yyyy-MM-dd HH:mm", null),
+                        Price = 2500.25m,
+                        SomeEnumType = ExampleClass.SomeEnum.Value2,
+                        SubType = new SomeSubType
+                        {
+                            OrderId = 26,
+                            Name = "EUR"
+                        }
+                    };
+                });
+
+            "When serialized to Dictionary<string, string>"
+                .x(() =>
+                {
+                    dictionary = expected.ToMetadataDictionary();
+                });
+
+            "And deserialized back to ExampleClass"
+                .x(() =>
+                {
+                    actual = dictionary.To<ExampleClass>();
+                });
+
+            "Then deserialized ExampleClass should be same as given ExampleClass"
+                .x(() =>
+                {
+                    actual.Should().BeEquivalentTo(expected);
+                });
+        }
+
+#pragma warning disable CA1034 // Nested types should not be visible
+        public class ExampleClass
+        {
+            public int Id { get; set; }
+
+            public string Name { get; set; }
+
+            public DateTime Timestamp { get; set; }
+
+            public decimal Price { get; set; }
+
+            public SomeEnum SomeEnumType { get; set; }
+
+            public SomeSubType SubType { get; set; }
+
+            public enum SomeEnum
+            {
+                Value1 = 0,
+                Value2,
+                Value3
+            }
+        }
+
+        public class SomeSubType
+        {
+            public int OrderId { get; set; }
+
+            public string Name { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
Added generic methods in Chest.Client to Add and Get metadata from chest.

Basically Chest has two endpoints which accepts metadata in Dictionary<string, string> and return the same type. These new generic methods do the serialization part inside client so the user will not need to serialize/deserialize instance objects to and from Dictionary<string, string>